### PR TITLE
Update serialNumber format and supply metadata.component.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.contrastsecurity</groupId>
 	<artifactId>jbom</artifactId>
 	<packaging>jar</packaging>
-	<version>1.2.2-SNAPSHOT</version>
+	<version>1.2.3-SNAPSHOT</version>
 
 	<name>jbom</name>
 	<description>Eclipse jbom generates "Runtime SBOMs" by directly measuring libraries and their use in running Java software (both local and remote).</description>

--- a/src/main/java/com/contrastsecurity/CycloneDXModel.java
+++ b/src/main/java/com/contrastsecurity/CycloneDXModel.java
@@ -27,16 +27,17 @@ public class CycloneDXModel extends Bom {
 	public CycloneDXModel() {
 		setVersion(1);
 		setMetadata( makeMetadata() );
-		setSerialNumber( UUID.randomUUID().toString() );
+		setSerialNumber( "urn:uuid:" + UUID.randomUUID().toString() );
 	}
 
 	public static Metadata makeMetadata() {
 		Metadata meta = new Metadata();
 		meta.setTimestamp( new Date() );
 		Tool jbom = new Tool();
+		String jbomVersion = getJbomVersion();
 		jbom.setName("jbom");
 		jbom.setVendor("Eclipse Foundation - https://projects.eclipse.org/projects/technology.jbom");
-		jbom.setVersion(getJbomVersion());
+		jbom.setVersion(jbomVersion);
 		meta.setTools( new ArrayList<>(Arrays.asList(jbom)) );
 
 		String description = "Java";
@@ -52,6 +53,7 @@ public class CycloneDXModel extends Bom {
 		Library appNode = new Library( hostname );
 		appNode.setType( Component.Type.APPLICATION );
 		appNode.setDescription( description );
+		appNode.setVersion( jbomVersion );
 		meta.setComponent( appNode );
 
 		OrganizationalEntity manufacturer = new OrganizationalEntity();


### PR DESCRIPTION
The strict schema validation was introduced in Dependency-Track API v4.11.0 (https://docs.dependencytrack.org/changelog):
> BOM Validation. Historically, Dependency-Track did not validate uploaded BOMs and VEXs against the CycloneDX schema. While this allowed BOMs to be processed that did not strictly adhere to the schema, it could also lead to confusion when uploaded files were accepted, but then failed to be ingested during asynchronous processing. Starting with this release, uploaded files will be rejected if they fail schema validation.
 
This PR adds cosmetics changes to comply with the [BOM schema](https://github.com/CycloneDX/specification/tree/master/schema).